### PR TITLE
Remove state manipulation and replace to `redux-ui`

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -3326,6 +3326,17 @@
         "sha.js": "^2.4.8"
       }
     },
+    "create-react-class": {
+      "version": "15.6.3",
+      "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.3.tgz",
+      "integrity": "sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==",
+      "dev": true,
+      "requires": {
+        "fbjs": "^0.8.9",
+        "loose-envify": "^1.3.1",
+        "object-assign": "^4.1.1"
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -7329,6 +7340,12 @@
       "version": "3.3.10",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
       "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+      "dev": true
+    },
+    "immutable": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
+      "integrity": "sha1-wkOZUUVbs5kT2vKBN28VMOEErfM=",
       "dev": true
     },
     "import-lazy": {
@@ -19363,6 +19380,50 @@
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.3.0.tgz",
       "integrity": "sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw==",
       "dev": true
+    },
+    "redux-ui": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/redux-ui/-/redux-ui-0.1.1.tgz",
+      "integrity": "sha1-6NMc8sh+2gjEmpNBeVWplKr+Hk4=",
+      "dev": true,
+      "requires": {
+        "babel-register": "^6.6.0",
+        "immutable": "^3.7.5",
+        "invariant": "^2.2.0",
+        "prop-types": "^15.5.7",
+        "react": "^0.14.9 || ^15.3.0",
+        "react-redux": "^4.0.0",
+        "redux": "^3.0.4"
+      },
+      "dependencies": {
+        "react": {
+          "version": "15.6.2",
+          "resolved": "https://registry.npmjs.org/react/-/react-15.6.2.tgz",
+          "integrity": "sha1-26BDSrQ5z+gvEI8PURZjkIF5qnI=",
+          "dev": true,
+          "requires": {
+            "create-react-class": "^15.6.0",
+            "fbjs": "^0.8.9",
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.0",
+            "prop-types": "^15.5.10"
+          }
+        },
+        "react-redux": {
+          "version": "4.4.9",
+          "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-4.4.9.tgz",
+          "integrity": "sha512-3XS7mjTOcvaP2H5OE/LxEgDHRuEyTZxBRlwvXHzNqYkZdYd7Ra98AimWoDSHP9OcLoydjA1ocgiZxxcqeXj0Sw==",
+          "dev": true,
+          "requires": {
+            "create-react-class": "^15.5.1",
+            "hoist-non-react-statics": "^2.5.0",
+            "invariant": "^2.0.0",
+            "lodash": "^4.2.0",
+            "loose-envify": "^1.1.0",
+            "prop-types": "^15.5.4"
+          }
+        }
+      }
     },
     "regenerate": {
       "version": "1.4.0",

--- a/client/package.json
+++ b/client/package.json
@@ -60,6 +60,7 @@
     "redux-promise": "^0.5.3",
     "redux-promise-middleware": "^5.1.1",
     "redux-thunk": "^2.2.0",
+    "redux-ui": "^0.1.1",
     "sanitize-html": "^1.18.4",
     "violet-paginator": "^3.0.0-beta-6",
     "webpack": "^4.12.2",

--- a/client/src/containers/NodeView/ForumComponent/createForumForm.js
+++ b/client/src/containers/NodeView/ForumComponent/createForumForm.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { Field, reduxForm } from 'redux-form';
-import { hideIfNoPermission, CAN_CREATE_FORUM } from "../../../utils/permissionChecker";
+import ui from 'redux-ui';
+import { hideIfNoPermission, CAN_CREATE_FORUM } from '../../../utils/permissionChecker';
 import './createForumForm.css';
 
 
@@ -19,22 +20,21 @@ const renderField = ({ input, label, type, placeholder, meta: { touched, error }
 class CreateForumForm extends Component {
     constructor(props) {
         super(props);
-        this.state = {opened: false};
     }
 
     render() {
-        const {error, handleSubmit, pristine, reset, submitting, onSubmit} = this.props;
+        const {error, handleSubmit, pristine, reset, submitting, onSubmit, ui} = this.props;
         const onSubmitHandler = (formValues) => {
             onSubmit(formValues);
-            this.setState({opened: false});
+            this.props.resetUI();
             reset();
         };
 
-        if (!this.state.opened) {
+        if (!ui.editing) {
             return (
                 <div className="mt-2">
                     <div className="open-btn">
-                        <button onClick={() => this.setState({opened: true})}>
+                        <button onClick={() => this.props.updateUI({'editing': true})}>
                             Create new forum
                         </button>
                     </div>
@@ -66,7 +66,7 @@ class CreateForumForm extends Component {
                             </button>
                             &nbsp;
                             <button type="button" disabled={submitting}
-                                    onClick={() => this.setState({opened: false})}
+                                    onClick={() => this.props.updateUI({'editing': false})}
                                     className="btn btn-secondary btn-sm">
                                 Close
                             </button>
@@ -79,4 +79,8 @@ class CreateForumForm extends Component {
 }
 
 export default hideIfNoPermission(CAN_CREATE_FORUM)
-    (reduxForm({form: 'createForumForm', enableReinitialize: true})(CreateForumForm))
+    (reduxForm({form: 'createForumForm', enableReinitialize: true})
+        (ui({state: {
+            editing: false
+        }})
+        (CreateForumForm)))

--- a/client/src/containers/NodeView/items/ReplyItem/index.js
+++ b/client/src/containers/NodeView/items/ReplyItem/index.js
@@ -1,16 +1,15 @@
-import React, { Component } from 'react'
-import UpdateReplyForm from './updateReplyForm';
+import React, { Component } from 'react';
+import ui from 'redux-ui';
 import TimeAgo from 'react-timeago';
 import {DeleteReplyButton} from '../../../../components/interactive-btns/DeleteButton';
 import EditButton from '../../../../components/interactive-btns/EditButton';
 import ToggleStickyButton from '../../../../components/interactive-btns/ToggleStickyButton';
+import UpdateReplyForm from './updateReplyForm';
 
 
-export default class ReplyItem extends Component {
+class ReplyItem extends Component {
     constructor(props) {
         super(props);
-        this.state = {'editing': false};
-
         this.startEditingHandler = this.startEditingHandler.bind(this);
         this.finishEditingHandler = this.finishEditingHandler.bind(this);
     }
@@ -19,19 +18,19 @@ export default class ReplyItem extends Component {
         // Init `editing` state if `node` is changed
         // (eg. reload is executed after editing finished)
         if (this.props.node !== prevProps.node)
-            this.setState({'editing': false});
+            this.props.resetUI();
     }
 
     startEditingHandler() {
-        this.setState({'editing': true});
+        this.props.updateUI({'editing': true});
     }
 
     finishEditingHandler() {
-        this.setState({'editing': false});
+        this.props.resetUI();
     }
 
     render() {
-        const {node, onEvent} = this.props;
+        const {node, onEvent, ui} = this.props;
 
         const onDeleteHandler = () => onEvent('DELETE', node._id);
         const onEditHandler = (values) => onEvent('UPDATE', node._id, values);
@@ -45,7 +44,7 @@ export default class ReplyItem extends Component {
             </div>
         );
 
-        if (this.state.editing) {
+        if (ui.editing) {
             return (
                 <li className="card reply-card">
                     {header}
@@ -74,3 +73,9 @@ export default class ReplyItem extends Component {
         }
     }
 }
+
+// Toggling to edit-mode is working with `redux-ui`,
+// it's useful block-level scoping with simple UI state.
+export default ui({state: {
+    editing: false
+}})(ReplyItem);

--- a/client/src/reducers.js
+++ b/client/src/reducers.js
@@ -1,6 +1,7 @@
 import { reducer as formReducer } from 'redux-form';
 import { reducer as modalReducer } from 'redux-modal';
 import { loadingBarReducer } from 'react-redux-loading-bar';
+import { reducer as uiReducer } from 'redux-ui';
 
 import {loginReducer} from './containers/Login/reducer';
 import {nodeViewReducer} from './containers/NodeView/reducer';
@@ -11,6 +12,7 @@ const allReducers = {
     modal: modalReducer,
     form: formReducer,
     loadingBar: loadingBarReducer,
+    ui: uiReducer,
     login: loginReducer,
     nodeView: nodeViewReducer,
     nodeEditor: nodeEditorReducer,


### PR DESCRIPTION
For `ReplyItem` and `createForumForm`, I used `setState` method to present and toggle state (editing mode / view mode).

That is not good method for react/redux design, so remove it and replace to `redux-ui`, which provides block-level scoping for UI state.

Now, there is no side effect on all components in `NodeView` 👍 