### PR TITLE
[CHANGE] error code about accessing soft-deleted node from 410 to 404

### DIFF
--- a/client/src/components/ErrorPageDeleted.js
+++ b/client/src/components/ErrorPageDeleted.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const Error410 = () => {
+const ErrorPageDeleted = () => {
     return (
         <div className="container mt-5 p-5 text-center">
             <h2 style={{fontSize: '40px'}}>Post is deleted</h2>
@@ -8,4 +8,4 @@ const Error410 = () => {
         </div>
     )
 };
-export default Error410;
+export default ErrorPageDeleted;

--- a/client/src/containers/NodeView/index.js
+++ b/client/src/containers/NodeView/index.js
@@ -3,7 +3,7 @@ import {connect} from 'react-redux';
 import Loading from '../../components/Loading';
 import ErrorMessage from '../../components/ErrorMessage';
 import Error404 from '../../components/Error404';
-import Error410 from '../../components/Error410';
+import ErrorPageDeleted from '../../components/ErrorPageDeleted';
 import ForumComponent from './ForumComponent';
 import TopicComponent from './TopicComponent';
 import * as actions from './actions';
@@ -69,12 +69,12 @@ class NodeView extends Component {
         const {node, children, pagination, error} = this.props;
         let component;
 
-        if (error && error.response.status === 404)
-            return <Error404 />;
-
-            if (error && error.response.status === 410)
-            return <Error410 />;
-
+        if (error && error.response.status === 404) {
+            if (error.response.data.deleted) 
+                return <ErrorPageDeleted />;
+            else
+                return <Error404 />;
+        }
         if (!node || !children) {
             // Node or children are not load yet.
             component = <Loading />;

--- a/server/api/middleware/loadNodeWithPermission.js
+++ b/server/api/middleware/loadNodeWithPermission.js
@@ -17,7 +17,7 @@ const errorInvalidType = { message: "Provided action type is not valid", code: 5
 const errorParentNodeNotFound = { message: "Parent node not found.", code: 404 };
 const errorMissingParameter = { message: "Parameter is missing.", code: 400 };
 const errorForbidden = { message: "Forbidden", code: 403 };
-const errorDeletedNode = { message: "Target node is deleted", code: 410 };
+const errorDeletedNode = { message: "Target node is deleted", code: 404, deleted: true };
 
 /**
  * Load node data from `req`
@@ -169,6 +169,6 @@ module.exports = (req, res, next) => {
                 throw result.fallbackError;
         })
         .catch((err) => {
-            res.status(err.code).json({ message: err.message });
+            res.status(err.code).json(err);
         })
 };

--- a/server/test/testMiddlewares.js
+++ b/server/test/testMiddlewares.js
@@ -120,7 +120,10 @@ describe('Test middlewares', function() {
             it('Read Deleted Forum', function () {
                 return supertest(app)
                     .get('/node/200000000000000000000006')
-                    .expect(410);
+                    .expect(404)
+                    .then(response => {
+                        assert(response.body.deleted === true);
+                    });
             });
             it('Update Forum', function () {
                 return supertest(app)
@@ -153,7 +156,10 @@ describe('Test middlewares', function() {
             it('Read Deleted Topic', function () {
                 return supertest(app)
                     .get('/node/200000000000000000000007')
-                    .expect(410)
+                    .expect(404)
+                    .then(response => {
+                        assert(response.body.deleted === true);
+                    });
             });
             it('Update Topic', function () {
                 return supertest(app)
@@ -197,7 +203,10 @@ describe('Test middlewares', function() {
             it('Read Deleted Forum', function () {
                 return supertest(app)
                     .get('/node/200000000000000000000006')
-                    .expect(410);
+                    .expect(404)
+                    .then(response => {
+                        assert(response.body.deleted === true);
+                    });
             });
             it('Update Forum', function () {
                 return supertest(app)
@@ -234,7 +243,10 @@ describe('Test middlewares', function() {
             it('Read Deleted Topic', function () {
                 return supertest(app)
                     .get('/node/200000000000000000000007')
-                    .expect(410)
+                    .expect(404)
+                    .then(response => {
+                        assert(response.body.deleted === true);
+                    });
             });
             it('Update Topic', function () {
                 return supertest(app)
@@ -362,7 +374,10 @@ describe('Test middlewares', function() {
                 // Subadmin can't read deleted node not having permission
                 return supertest(app)
                     .get('/node/200000000000000000000007')
-                    .expect(410)
+                    .expect(404)
+                    .then(response => {
+                        assert(response.body.deleted === true);
+                    });
             });
         });
 


### PR DESCRIPTION
Because 410 error use browser caching, after login as permitted user, don't reload page.

Therefore, change from 410 to 404 and add deleted field in error.response. 
It is handled in index.js at NodeView.